### PR TITLE
Update development infrastructure

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-performance
+  - rubocop-packaging
   - rubocop-rspec
 
 AllCops:
@@ -40,6 +41,11 @@ Lint/AssignmentInCondition:
 Metrics/BlockLength:
   Exclude:
     - ghtml2pdf.gemspec
+
+# require_relative makes sense in gemspec
+Packaging/RelativeRequireToLib:
+  Exclude:
+    - '*.gemspec'
 
 Performance/StartWith:
   AutoCorrect: true

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,0 +1,9 @@
+lib/ghtml2pdf
+lib/ghtml2pdf.rb
+lib/ghtml2pdf/application.rb
+lib/ghtml2pdf/argument_parser.rb
+lib/ghtml2pdf/print_settings.rb
+lib/ghtml2pdf/version.rb
+Changelog.md
+README.md
+LICENSE.txt

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
+require "rake/manifest/task"
 require "rspec/core/rake_task"
 require "cucumber/rake/task"
+
+Rake::Manifest::Task.new do |t|
+  t.patterns = ["lib/**/*", "*.md", "LICENSE.txt"]
+end
 
 Cucumber::Rake::Task.new(:features) do |t|
   t.cucumber_opts = "features --format pretty"

--- a/ghtml2pdf.gemspec
+++ b/ghtml2pdf.gemspec
@@ -37,4 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.1.0"
   spec.add_development_dependency "rspec", "~> 3.3"
+  spec.add_development_dependency "rubocop", "~> 0.89.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.7.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 1.42.0"
 end

--- a/ghtml2pdf.gemspec
+++ b/ghtml2pdf.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-manifest", "~> 0.1.0"
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "rubocop", "~> 0.89.0"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.2.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.7.0"
   spec.add_development_dependency "rubocop-rspec", "~> 1.42.0"
 end

--- a/ghtml2pdf.gemspec
+++ b/ghtml2pdf.gemspec
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "ghtml2pdf/version"
+require_relative "lib/ghtml2pdf/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "ghtml2pdf"
@@ -15,9 +13,14 @@ Gem::Specification.new do |spec|
     Clean Ruby implemenentation of a HTML to PDF
     converter based on WebKit, WebKit2GTK+ and GirFFI
   '
-  spec.required_ruby_version = ">= 2.5.0"
   spec.homepage      = "https://github.com/mvz/ghtml2pdf"
   spec.license       = "MIT"
+
+  spec.required_ruby_version = ">= 2.5.0"
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/mvz/ghtml2pdf"
+  spec.metadata["changelog_uri"] = "https://github.com/mvz/ghtml2pdf/blob/master/Changelog.md"
 
   spec.files         = Dir["lib/**/*.rb",
                            "Changelog.md",

--- a/ghtml2pdf.gemspec
+++ b/ghtml2pdf.gemspec
@@ -22,10 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/mvz/ghtml2pdf"
   spec.metadata["changelog_uri"] = "https://github.com/mvz/ghtml2pdf/blob/master/Changelog.md"
 
-  spec.files         = Dir["lib/**/*.rb",
-                           "Changelog.md",
-                           "LICENSE.txt",
-                           "README.md"]
+  spec.files = File.read("Manifest.txt").split
   spec.bindir        = "bin"
   spec.executables   = ["ghtml2pdf"]
   spec.require_paths = ["lib"]
@@ -38,5 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "cucumber", "~> 4.0"
   spec.add_development_dependency "pdf-reader", "~> 2.4.0"
   spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rake-manifest", "~> 0.1.0"
   spec.add_development_dependency "rspec", "~> 3.3"
 end

--- a/lib/ghtml2pdf/application.rb
+++ b/lib/ghtml2pdf/application.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require "gir_ffi-gtk3"
-require_relative "argument_parser"
-require_relative "print_settings"
+require "ghtml2pdf/argument_parser"
+require "ghtml2pdf/print_settings"
 
 GirFFI.setup :WebKit2
 


### PR DESCRIPTION
- Make gemspec use a manifest file instead of git
- Add rubocop gems as dependencies to control versions
- Add rubocop-packaging and fix offenses