### PR TITLE
Update cucumber development dependency

### DIFF
--- a/ghtml2pdf.gemspec
+++ b/ghtml2pdf.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ruby-units", "~> 2.2"
 
   spec.add_development_dependency "aruba", "~> 1.0"
-  spec.add_development_dependency "cucumber", "~> 4.0"
+  spec.add_development_dependency "cucumber", "~> 5.0"
   spec.add_development_dependency "pdf-reader", "~> 2.4.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.1.0"


### PR DESCRIPTION
This bumps the cucumber dependency to the latest version, which is 5.