### PR TITLE
Fix build in GitHub Actions with Ubuntu Jammy

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,6 +29,8 @@ jobs:
           sudo apt-get update
           # Provides libgirepository-1.0.so.1
           sudo apt-get install libgirepository-1.0-1
+          # BUG: Missing dependency of gir1.2-harfbuzz-0.0
+          sudo apt-get install libharfbuzz-gobject0
           # Provides Gtk-3.0.typelib
           sudo apt-get install gir1.2-gtk-3.0
           # Provides Atspi-2.0.typelib


### PR DESCRIPTION
This adds a missing dependency that should be automatically installed.
