### PR TITLE
Bump RuboCop dependency versions and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.7
 
+# Put development dependencies in the gemspec so rubygems.org knows about them
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 # Spaces in strings with line continuations go at the beginning of the line.
 Layout/LineContinuationLeadingSpace:
   EnforcedStyle: leading

--- a/ghtml2pdf.gemspec
+++ b/ghtml2pdf.gemspec
@@ -35,8 +35,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "rubocop", "~> 1.32"
+  spec.add_development_dependency "rubocop", "~> 1.51"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.13"
-  spec.add_development_dependency "rubocop-rspec", "~> 2.9"
+  spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.22"
 end


### PR DESCRIPTION
- Bump versions for rubocop dependencies
- Require development dependencies to be in the gemspec
