### PR TITLE
Disable RSpec/FilePath explicitly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,6 +98,10 @@ Style/WordArray:
 
 # Project-specific configuration goes here.
 
+# Disabled because RSpec/SpecFilePathFormat is automatically enabled as a new cop
+RSpec/FilePath:
+  Enabled: false
+
 # Tell SpecFilePathFormat about custom file name
 RSpec/SpecFilePathFormat:
   CustomTransform:


### PR DESCRIPTION
This cop was re-enabled in rubocop-rspec, but the configuration for this project was already moved to RSpec/SpecFilePathFormat, so use that one instead.
