### PR TITLE
Fix cucumber step implementation and page size expectation

### DIFF
--- a/features/step_definitions/page_property_steps.rb
+++ b/features/step_definitions/page_property_steps.rb
@@ -4,17 +4,17 @@ require "pdf/reader"
 require "stringio"
 
 Then(/^the file "([^"]*)" should have default page properties$/) do |file|
-  pdf_data = read(file).join("\n")
-  io = StringIO.new(pdf_data)
+  io = File.open expand_path(file)
   reader = PDF::Reader.new(io)
 
   reader.pages.each do |page|
     box = page.attributes[:MediaBox]
+
     aggregate_failures "A4 page size" do
       expect(box[0]).to eq 0
       expect(box[1]).to eq 0
-      expect(box[2]).to be_within(0.01).of 595.28
-      expect(box[3]).to be_within(0.01).of 841.89
+      expect(box[2]).to eq 595
+      expect(box[3]).to eq 842
     end
   end
 end


### PR DESCRIPTION
- Using the Aruba read method is unreliable since it removes information by returning chomped lines
- The MediaBox created now has integer dimensions for some reason
