### PR TITLE
Switch CI back to ubuntu-latest and update apt dependencies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ name: CI
 jobs:
   test:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -39,7 +39,7 @@ jobs:
           # Needed to avoid warnings about retrieving accessibility bus address
           sudo apt-get install at-spi2-core
           # GIR data for GtkWebkit 4
-          sudo apt-get install gir1.2-webkit2-4.0 --no-install-recommends
+          sudo apt-get install gir1.2-webkit2-4.1 --no-install-recommends
           # Provides xvfb-run
           sudo apt-get install xvfb
 


### PR DESCRIPTION
Because `ghtml2pdf` now depends on `gir_ffi` 0.18.0, running on ubuntu-latest (24.04) has become possible without installing gobject dev packages.

Switching to `gir1.2-webkit2-4.1` is needed because Ubuntu 24.04 does not include `gir1.2-webkit2-4.0`.
