### PR TITLE
Bump RuboCop dependency versions and fix new offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,10 +7,6 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 3.2
 
-# Put development dependencies in the gemspec so rubygems.org knows about them
-Gemspec/DevelopmentDependencies:
-  EnforcedStyle: gemspec
-
 # Spaces in strings with line continuations go at the beginning of the line.
 Layout/LineContinuationLeadingSpace:
   EnforcedStyle: leading

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,8 @@ group :development, :test do
   gem "rake", "~> 13.0"
   gem "rake-manifest", "~> 0.2.0"
   gem "rspec", "~> 3.3"
-  gem "rubocop", "~> 1.80"
+  gem "rubocop", "~> 1.86"
   gem "rubocop-packaging", "~> 0.6.0"
-  gem "rubocop-performance", "~> 1.25"
-  gem "rubocop-rspec", "~> 3.7"
+  gem "rubocop-performance", "~> 1.26"
+  gem "rubocop-rspec", "~> 3.9"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,18 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in ghtml2pdf.gemspec
+# Runtime dependencies are specified in ghtml2pdf.gemspec
 gemspec
+
+group :development, :test do
+  gem "aruba", "~> 2.3"
+  gem "cucumber", "~> 10.0"
+  gem "pdf-reader", "~> 2.9"
+  gem "rake", "~> 13.0"
+  gem "rake-manifest", "~> 0.2.0"
+  gem "rspec", "~> 3.3"
+  gem "rubocop", "~> 1.80"
+  gem "rubocop-packaging", "~> 0.6.0"
+  gem "rubocop-performance", "~> 1.25"
+  gem "rubocop-rspec", "~> 3.7"
+end

--- a/features/step_definitions/page_property_steps.rb
+++ b/features/step_definitions/page_property_steps.rb
@@ -4,10 +4,12 @@ require "pdf/reader"
 require "stringio"
 
 Then(/^the file "([^"]*)" should have default page properties$/) do |file|
-  io = File.open expand_path(file)
-  reader = PDF::Reader.new(io)
+  pages = File.open expand_path(file) do |io|
+    reader = PDF::Reader.new(io)
+    reader.pages
+  end
 
-  reader.pages.each do |page|
+  pages.each do |page|
     box = page.attributes[:MediaBox]
 
     aggregate_failures "A4 page size" do

--- a/ghtml2pdf.gemspec
+++ b/ghtml2pdf.gemspec
@@ -29,15 +29,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gir_ffi", "~> 0.18.0"
   spec.add_dependency "gir_ffi-gtk", "~> 0.18.0"
   spec.add_dependency "ruby-units", "~> 4.0"
-
-  spec.add_development_dependency "aruba", "~> 2.3"
-  spec.add_development_dependency "cucumber", "~> 10.0"
-  spec.add_development_dependency "pdf-reader", "~> 2.9"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "rubocop", "~> 1.80"
-  spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.25"
-  spec.add_development_dependency "rubocop-rspec", "~> 3.7"
 end


### PR DESCRIPTION
- **Move development dependencies to the Gemfile**
- **Bump minimum RuboCop dependency versions**
- **Fix Style/FileOpen offense**
