### PR TITLE
Restore use of headless gem

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get install at-spi2-core
           # GIR data for GtkWebkit 4
           sudo apt-get install gir1.2-webkit2-4.1 --no-install-recommends
-          # Provides xvfb-run
+          # Provides xvfb-run used by the headless gem
           sudo apt-get install xvfb
 
       - name: Set up Ruby
@@ -46,8 +46,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Run tests in a dbus session
-        run: xvfb-run dbus-run-session bundle exec rake
+      - name: Run tests
+        run: dbus-run-session bundle exec rake
 
   rubocop:
 

--- a/bin/ghtml2pdf
+++ b/bin/ghtml2pdf
@@ -2,5 +2,8 @@
 # frozen_string_literal: true
 
 require "ghtml2pdf"
+require "headless"
 
-GHtml2Pdf.run(ARGV)
+Headless.ly do
+  GHtml2Pdf.run(ARGV)
+end

--- a/ghtml2pdf.gemspec
+++ b/ghtml2pdf.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "gir_ffi", "~> 0.19.0"
   spec.add_dependency "gir_ffi-gtk", "~> 0.19.0"
+  spec.add_dependency "headless", "~> 3.0.0"
   spec.add_dependency "ruby-units", "~> 4.0"
 end


### PR DESCRIPTION
- **Use headless again, updating to version 3.0**
- **Run tests in CI without wrapping X session**
